### PR TITLE
fix: player in queueOut array can sometimes be nil

### DIFF
--- a/src/Index/Server/ServerProcess.luau
+++ b/src/Index/Server/ServerProcess.luau
@@ -154,6 +154,7 @@ function ServerProcess.start()
 		for Identifier: string, players in serverQueue do
 			for player: Player, data in players do
 				if #data > 0 then
+					if not queueOut[player] then continue end
 					queueOut[player][Identifier] = table.clone(data)
 					table.clear(data)
 				end


### PR DESCRIPTION
Fixes error:

```
  21:16:46.050  ServerProcess:157: attempt to index nil with ''  -  Server - ServerProcess:157
```