### PR TITLE
Client warning and timeout of 10s

### DIFF
--- a/src/Index/Client/Index.luau
+++ b/src/Index/Client/Index.luau
@@ -14,9 +14,12 @@ local Serdes = require(Util.Serdes)
 local Buffer = require(Util.Buffer)
 
 function Client.new(Identifier: string)
+	local id = Serdes(Identifier)
+	if not id then return end
+
 	local self = setmetatable({}, Client)
 	self._buffer = Buffer.new()
-	self._buffer:wu8(Serdes(Identifier))
+	self._buffer:wu8()
 	self.id = Buffer.convert(self._buffer:build())
 	self.fn = {}
 	self.IsConnected = false

--- a/src/Index/Client/Index.luau
+++ b/src/Index/Client/Index.luau
@@ -19,7 +19,7 @@ function Client.new(Identifier: string)
 
 	local self = setmetatable({}, Client)
 	self._buffer = Buffer.new()
-	self._buffer:wu8()
+	self._buffer:wu8(id)
 	self.id = Buffer.convert(self._buffer:build())
 	self.fn = {}
 	self.IsConnected = false

--- a/src/Index/Util/Serdes.luau
+++ b/src/Index/Util/Serdes.luau
@@ -15,9 +15,18 @@ return function(Identifier: string): number
 			--Event:SetAttribute(Identifier, string.pack("I1", SerInt)) -- I1 -> 255 max, I2 -> ~ 6.5e4 max. (SerInt)
 		end
 	else
-		while not Event:GetAttribute(Identifier) do
-			task.wait(0.5)
+		local loaded, timedout
+		task.delay(10, function()
+		    if loaded then return end
+		    timedout = true
+		    warn(`{Identifier} is taking too long to retrieve.`)
+		end)
+		
+		while not Event:GetAttribute(Identifier) and not timedout do
+		    task.wait(0.5)
 		end
+		loaded = true
+		if timedout then return end
 	end
 	return Event:GetAttribute(Identifier)
 end


### PR DESCRIPTION
In case of an infinite yield on the server for an identifier, the client is warned and nothing is returned.