### PR TITLE
Changing `Warp` from a regular to a strict table. Adding the ability …

### DIFF
--- a/docs/api/1.1/client.md
+++ b/docs/api/1.1/client.md
@@ -6,6 +6,8 @@ For Client-sided operations.
 
 ```lua
 local Client = Warp.Client()
+--..or..--
+local Client = Warp.Client
 ```
 
 ## `.awaitReady` <Badge type="warning" text="yield" />

--- a/docs/api/1.1/server.md
+++ b/docs/api/1.1/server.md
@@ -6,6 +6,8 @@ For Server-sided operations.
 
 ```lua
 local Server = Warp.Server()
+--..or..--
+local Server = Warp.Server
 ```
 
 ## `.reg_namespaces`

--- a/docs/api/1.1/warp.md
+++ b/docs/api/1.1/warp.md
@@ -11,7 +11,7 @@ Get the Server operation for server-side.
 
 ```lua
 -- Server
-local Server = Warp.Server()
+local Server = Warp.Server
 ```
 
 ## `.Client` <Badge type="tip" text="client side" />
@@ -20,7 +20,7 @@ Get the Client operation for client-side.
 
 ```lua
 -- Client
-local Client = Warp.Client()
+local Client = Warp.Client
 ```
 
 ## `.Buffer` <Badge type="tip" text="universal" />

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,6 +12,11 @@ Then, you should do `.Server` or `.Client`
 ```lua
 local Server = Warp.Server() --> for Server-side only
 local Client = Warp.Client() --> for Client-side only
+
+--..or..--
+
+local Server = Warp.Server
+local Client = Warp.Client
 ```
 
 ### `Basic Usage`

--- a/src/init.luau
+++ b/src/init.luau
@@ -1,8 +1,9 @@
 --!strict
 --@EternityDev
+
 local Remote = {}
 
-if game.RunService:IsServer() then
+if game:GetService("RunService"):IsServer() then
 	if not script:FindFirstChild("_repl") then
 		Instance.new("RemoteEvent", script).Name = "_repl"
 	end
@@ -21,18 +22,24 @@ local Buffer = require("@self/Util/Buffer")
 --[[
 	@class Remote
 	@client
+	client library of `Warp`, use it only on client
 ]]
-Remote.Client = function()
-	return Client
-end
+Remote.Client = setmetatable(Client, {
+	__call = function()
+		return Client
+	end,
+})
 
 --[[
 	@class Remote
 	@server
+	server library of `Warp`, use it only on server
 ]]
-Remote.Server = function()
-	return Server
-end
+Remote.Server = setmetatable(Server, {
+	__call = function()
+		return Server
+	end,
+})
 
 --[[
 	@class Remote
@@ -41,4 +48,13 @@ end
 ]]
 Remote.Buffer = Buffer
 
-return Remote :: typeof(Remote)
+-- making a strict table from `Warp` (Remote) - catching early errors and preventing changes/replacements of keys in the table
+return setmetatable(Remote, {
+	__index = function(_self: any, key: any): never
+		error(`{key} is not valid member of Warp.\nPlease check documentation here: https://imezx.github.io/Warp/`)
+	end,
+
+	__newindex = function(_self: any, key: any, _value: any): never
+		error(`{key} is not valid member of Warp.\nPlease check documentation here: https://imezx.github.io/Warp/`)
+	end,
+}) :: typeof(Remote) -- saving the typing


### PR DESCRIPTION
…to use `Client` and `Server` without calling fn(); (Like Buffer) + Prettier init.luau

Why Strict Table instead Regular?
- Catching early syntax errors.
- Preventing changes/replacements of keys in the table.
- Better Error handling with link to Documentation.

Why `metatable` instead `fn()` for `Server` and `Client`?
- Flexibility (now you can use ".Client" and ".Client()" without losing typing).
- More convenient use - for me personally, it will be more convenient to use one API retrieval interface (including for Warp), as Buffer is currently retrieved directly, but Client and Server - not.

All Changes - Backward compatibility and with full typization safing.
Also, I Fixed Type Error for line 6 (RunService get) and made the script prettier.